### PR TITLE
fix: no source maps in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "rm -rf dist && parcel examples/index.html --open",
     "build": "rm -rf dist && ./node_modules/.bin/tsc --module CommonJS",
-    "prepublishOnly": "yarn build && yarn test",
+    "build:production": "yarn build -p tsconfig.production.json",
+    "prepublishOnly": "yarn test && yarn build:production",
     "test": "yarn test:server && yarn test:browser",
     "test:server": "tsc -p . --noEmit && tsc -p . && jest --env=node useSSR-server.test.ts",
     "test:server:watch": "tsc -p . --noEmit && tsc -p . && jest --watch --env=node useSSR-server.test.ts",

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
Hi 👋, it's me again 😄!

### Description

Currently, source maps are generated in the production build but they point to source files that don't exist in the distribution.

### Solution

I suggest to disable source maps generation during the production build.